### PR TITLE
Escape sequences

### DIFF
--- a/lib/json5.js
+++ b/lib/json5.js
@@ -237,7 +237,8 @@ JSON5.parse = (function () {
                         } else if (typeof escapee[ch] === 'string') {
                             string += escapee[ch];
                         } else {
-                            break;
+                            // javascript treats the '\' char as an escape for any character
+                            string += ch;
                         }
                     } else if (ch === '\n') {
                         // unescaped newlines are invalid; see:


### PR DESCRIPTION
don't throw parse errors for invalid escape sequences
- javascript style parse support
